### PR TITLE
fix: parse nested JSON values for body flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -154,11 +154,11 @@ async function runApiCommand(
   const headers = buildHeaders(profile);
 
   const knownOptionNames = new Set(command.options.map((o) => o.name));
-  const body: Record<string, string> = {};
+  const body: Record<string, unknown> = {};
 
   Object.keys(flags).forEach((key) => {
     if (!knownOptionNames.has(key)) {
-      body[key] = flags[key];
+      body[key] = parseBodyFlagValue(flags[key]);
     }
   });
 
@@ -177,6 +177,24 @@ async function runApiCommand(
 
   const response = await httpClient.request(requestConfig);
   stdout(`${JSON.stringify(response.data, null, 2)}\n`);
+}
+
+function parseBodyFlagValue(value: string): unknown {
+  const trimmed = value.trim();
+
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (trimmed === "null") return null;
+
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      throw new Error(`Invalid JSON body value: ${trimmed}`);
+    }
+  }
+
+  return value;
 }
 
 function parseArgs(args: string[]): { flags: Record<string, string>; positional: string[] } {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -576,6 +576,180 @@ describe("cli", () => {
     expect(out).toContain('"ok": true');
   });
 
+  // --- Body flag JSON parsing tests ---
+
+  function createPostApiDeps() {
+    const localDir = `${cwd}/.ocli`;
+    const profilesPath = `${localDir}/profiles.ini`;
+    const cachePath = `${localDir}/specs/body-api.json`;
+
+    const spec = {
+      openapi: "3.0.0",
+      paths: {
+        "/{org_slug}/{repo_slug}/ci/workflows/{workflow_name}/trigger": {
+          post: {
+            summary: "Trigger workflow",
+            parameters: [
+              { name: "org_slug", in: "path", required: true, schema: { type: "string" } },
+              { name: "repo_slug", in: "path", required: true, schema: { type: "string" } },
+              { name: "workflow_name", in: "path", required: true, schema: { type: "string" } },
+            ],
+          },
+        },
+      },
+    };
+
+    const iniContent = [
+      "[body-api]",
+      "api_base_url = https://api.example.com",
+      "api_basic_auth = ",
+      "api_bearer_token = tok",
+      "openapi_spec_source = /spec.json",
+      `openapi_spec_cache = ${cachePath}`,
+      "include_endpoints = ",
+      "exclude_endpoints = ",
+      "",
+    ].join("\n");
+
+    const capturedConfigs: unknown[] = [];
+    const fakeHttpClient: HttpClient = {
+      request: async (config: any) => {
+        capturedConfigs.push(config);
+        return { status: 200, statusText: "OK", headers: {}, config, data: { ok: true } };
+      },
+    };
+
+    const { profileStore, openapiLoader } = createCliDeps(cwd, homeDir, {
+      [profilesPath]: iniContent,
+      [cachePath]: JSON.stringify(spec),
+      [`${localDir}/current`]: "body-api",
+    });
+
+    return { profileStore, openapiLoader, fakeHttpClient, capturedConfigs };
+  }
+
+  it("parses JSON object body flags before sending request", async () => {
+    const { profileStore, openapiLoader, fakeHttpClient, capturedConfigs } = createPostApiDeps();
+
+    await run(
+      [
+        "org_slug_repo_slug_ci_workflows_workflow_name_trigger",
+        "--org_slug", "myorg",
+        "--repo_slug", "myrepo",
+        "--workflow_name", "deploy",
+        "--revision", "main",
+        "--workflow_revision", "main",
+        "--input", '{"values":[{"name":"FOO","value":"bar"}]}',
+      ],
+      { cwd, profileStore, openapiLoader, httpClient: fakeHttpClient, stdout: () => {} }
+    );
+
+    expect(capturedConfigs).toHaveLength(1);
+    const config = capturedConfigs[0] as { data: Record<string, unknown> };
+    expect(config.data).toEqual({
+      revision: "main",
+      workflow_revision: "main",
+      input: {
+        values: [{ name: "FOO", value: "bar" }],
+      },
+    });
+  });
+
+  it("parses boolean body flags before sending request", async () => {
+    const { profileStore, openapiLoader, fakeHttpClient, capturedConfigs } = createPostApiDeps();
+
+    await run(
+      [
+        "org_slug_repo_slug_ci_workflows_workflow_name_trigger",
+        "--org_slug", "myorg",
+        "--repo_slug", "myrepo",
+        "--workflow_name", "deploy",
+        "--shared", "true",
+        "--draft", "false",
+      ],
+      { cwd, profileStore, openapiLoader, httpClient: fakeHttpClient, stdout: () => {} }
+    );
+
+    expect(capturedConfigs).toHaveLength(1);
+    const config = capturedConfigs[0] as { data: Record<string, unknown> };
+    expect(config.data.shared).toBe(true);
+    expect(config.data.draft).toBe(false);
+  });
+
+  it("parses null body flags before sending request", async () => {
+    const { profileStore, openapiLoader, fakeHttpClient, capturedConfigs } = createPostApiDeps();
+
+    await run(
+      [
+        "org_slug_repo_slug_ci_workflows_workflow_name_trigger",
+        "--org_slug", "myorg",
+        "--repo_slug", "myrepo",
+        "--workflow_name", "deploy",
+        "--description", "null",
+      ],
+      { cwd, profileStore, openapiLoader, httpClient: fakeHttpClient, stdout: () => {} }
+    );
+
+    expect(capturedConfigs).toHaveLength(1);
+    const config = capturedConfigs[0] as { data: Record<string, unknown> };
+    expect(config.data.description).toBeNull();
+  });
+
+  it("parses JSON array body flags before sending request", async () => {
+    const { profileStore, openapiLoader, fakeHttpClient, capturedConfigs } = createPostApiDeps();
+
+    await run(
+      [
+        "org_slug_repo_slug_ci_workflows_workflow_name_trigger",
+        "--org_slug", "myorg",
+        "--repo_slug", "myrepo",
+        "--workflow_name", "deploy",
+        "--tags", '["ci","deploy"]',
+      ],
+      { cwd, profileStore, openapiLoader, httpClient: fakeHttpClient, stdout: () => {} }
+    );
+
+    expect(capturedConfigs).toHaveLength(1);
+    const config = capturedConfigs[0] as { data: Record<string, unknown> };
+    expect(config.data.tags).toEqual(["ci", "deploy"]);
+  });
+
+  it("preserves plain string body flags", async () => {
+    const { profileStore, openapiLoader, fakeHttpClient, capturedConfigs } = createPostApiDeps();
+
+    await run(
+      [
+        "org_slug_repo_slug_ci_workflows_workflow_name_trigger",
+        "--org_slug", "myorg",
+        "--repo_slug", "myrepo",
+        "--workflow_name", "deploy",
+        "--revision", "main",
+      ],
+      { cwd, profileStore, openapiLoader, httpClient: fakeHttpClient, stdout: () => {} }
+    );
+
+    expect(capturedConfigs).toHaveLength(1);
+    const config = capturedConfigs[0] as { data: Record<string, unknown> };
+    expect(config.data.revision).toBe("main");
+  });
+
+  it("throws on invalid JSON-like body flags", async () => {
+    const { profileStore, openapiLoader, fakeHttpClient } = createPostApiDeps();
+
+    await expect(
+      run(
+        [
+          "org_slug_repo_slug_ci_workflows_workflow_name_trigger",
+          "--org_slug", "myorg",
+          "--repo_slug", "myrepo",
+          "--workflow_name", "deploy",
+          "--input", '{"values":',
+        ],
+        { cwd, profileStore, openapiLoader, httpClient: fakeHttpClient, stdout: () => {} }
+      )
+    ).rejects.toThrow("Invalid JSON body value");
+  });
+
   it("sends custom headers from profile in API requests", async () => {
     const localDir = `${cwd}/.ocli`;
     const profilesPath = `${localDir}/profiles.ini`;


### PR DESCRIPTION
## Summary

`openapi-to-cli` assembles JSON request bodies from CLI flags, but nested values (objects, arrays) are sent as raw strings instead of parsed JSON. This makes endpoints expecting nested payloads unusable.

**Before** (broken):
```json
{
  "revision": "main",
  "input": "{\"values\":[{\"name\":\"FOO\",\"value\":\"bar\"}]}"
}
```

**After** (fixed):
```json
{
  "revision": "main",
  "input": {
    "values": [{ "name": "FOO", "value": "bar" }]
  }
}
```

## Root cause

In `runApiCommand()`, unknown flags (body fields) are copied into the request body as-is. Since `parseArgs()` treats all values as strings, JSON objects/arrays remain strings.

## Changes

- Added `parseBodyFlagValue()` helper in `src/cli.ts` that:
  - Parses values starting with `{` or `[` as JSON
  - Converts `true`/`false`/`null` literals to JSON primitives
  - Throws a clear error on malformed JSON-like values
  - Leaves plain strings unchanged
- Applied only to body fields (path/query parameters are unaffected)
- Added 6 regression tests in `tests/cli.test.ts`

## Intentional limitations

- Numbers are **not** auto-coerced (avoids breaking APIs expecting `"123"` as a string)
- This is not schema-aware — a follow-up could extract body options from the OpenAPI spec for richer `--help` and validation

## Test plan

- [x] JSON object body flag → parsed as object
- [x] JSON array body flag → parsed as array
- [x] Boolean body flags (`true`/`false`) → parsed as booleans
- [x] `null` body flag → parsed as null
- [x] Plain string body flag → preserved as string
- [x] Invalid JSON-like body flag → throws clear error
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)