### PR TITLE
fix: profile apiBaseUrl takes priority over spec root server URL

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -247,7 +247,11 @@ function buildRequestUrl(profile: Profile, command: CliCommand, flags: Record<st
       }
     });
 
-  const baseUrl = (command.serverUrl ?? profile.apiBaseUrl).replace(/\/+$/, "");
+  const baseUrl = (
+    command.serverUrlOverridesProfile
+      ? command.serverUrl ?? ""
+      : profile.apiBaseUrl || command.serverUrl || ""
+  ).replace(/\/+$/, "");
   let url = baseUrl ? `${baseUrl}${pathValue}` : pathValue;
 
   const queryParts: string[] = [];

--- a/src/openapi-to-commands.ts
+++ b/src/openapi-to-commands.ts
@@ -25,6 +25,7 @@ export interface CliCommand {
   description?: string;
   requestContentType?: string;
   serverUrl?: string;
+  serverUrlOverridesProfile?: boolean;
 }
 
 type HttpMethod = "get" | "post" | "put" | "delete" | "patch" | "head" | "options" | "trace";
@@ -185,7 +186,7 @@ export class OpenapiToCommands {
         const name = multipleMethods ? `${baseName}_${op.method}` : baseName;
         const { options, requestContentType } = this.extractOptions(op, spec);
         const description = op.operation.summary ?? op.operation.description;
-        const serverUrl = this.resolveOperationServerUrl(spec, op);
+        const resolved = this.resolveOperationServerUrl(spec, op);
 
         commands.push({
           name,
@@ -194,7 +195,8 @@ export class OpenapiToCommands {
           options,
           description,
           requestContentType,
-          serverUrl,
+          serverUrl: resolved.url,
+          serverUrlOverridesProfile: resolved.overridesProfile,
         });
       }
     }
@@ -540,23 +542,28 @@ export class OpenapiToCommands {
     };
   }
 
-  private resolveOperationServerUrl(spec: OpenapiSpecLike, op: PathOperation): string | undefined {
+  private resolveOperationServerUrl(
+    spec: OpenapiSpecLike,
+    op: PathOperation
+  ): { url?: string; overridesProfile?: boolean } {
     const rootBase = this.resolveServers(Array.isArray(spec?.servers) ? spec.servers : undefined);
+
     const operationServer = this.resolveServers(op.operation.servers, rootBase);
     if (operationServer) {
-      return operationServer;
+      return { url: operationServer, overridesProfile: true };
     }
 
     const pathServer = this.resolveServers(op.pathServers, rootBase);
     if (pathServer) {
-      return pathServer;
+      return { url: pathServer, overridesProfile: true };
     }
 
     if (rootBase) {
-      return rootBase;
+      return { url: rootBase, overridesProfile: false };
     }
 
-    return this.resolveSwagger2BaseUrl(spec);
+    const swagger2Base = this.resolveSwagger2BaseUrl(spec);
+    return swagger2Base ? { url: swagger2Base, overridesProfile: false } : {};
   }
 
   private resolveServers(rawServers?: unknown[], relativeTo?: string): string | undefined {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1373,4 +1373,69 @@ describe("cli", () => {
     expect(profile?.customHeaders).toEqual({ "X-Custom-Id": "abc123", "X-Tenant": "myorg" });
     expect(profile?.commandPrefix).toBe("");
   });
+
+  it.each([
+    {
+      label: "swagger 2.0 host",
+      spec: { swagger: "2.0", host: "gitlab.com", basePath: "/api/v4", schemes: ["https"], paths: { "/version": { get: { summary: "v" } } } },
+      cmd: "version",
+    },
+    {
+      label: "openapi 3.0 root servers",
+      spec: { openapi: "3.0.0", servers: [{ url: "https://public.example.com/api" }], paths: { "/status": { get: { summary: "s" } } } },
+      cmd: "status",
+    },
+  ])("profile apiBaseUrl takes priority over $label", async ({ spec, cmd }) => {
+    const localDir = `${cwd}/.ocli`;
+    const cachePath = `${localDir}/specs/p.json`;
+    const capturedConfigs: unknown[] = [];
+    const fakeHttpClient: HttpClient = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      request: async (config: any) => {
+        capturedConfigs.push(config);
+        return { status: 200, statusText: "OK", headers: {}, config, data: {} };
+      },
+    };
+    const { profileStore, openapiLoader } = createCliDeps(cwd, homeDir, {
+      [`${localDir}/profiles.ini`]: ["[p]", "api_base_url = https://self-hosted.example.com", `openapi_spec_cache = ${cachePath}`, ""].join("\n"),
+      [cachePath]: JSON.stringify(spec),
+      [`${localDir}/current`]: "p",
+    });
+
+    await run([cmd], { cwd, profileStore, openapiLoader, httpClient: fakeHttpClient, stdout: () => {} });
+
+    const config = capturedConfigs[0] as { url: string };
+    expect(config.url).toContain("self-hosted.example.com");
+    expect(config.url).not.toContain("gitlab.com");
+    expect(config.url).not.toContain("public.example.com");
+  });
+
+  it("path-level servers override profile apiBaseUrl", async () => {
+    const localDir = `${cwd}/.ocli`;
+    const cachePath = `${localDir}/specs/ps.json`;
+    const spec = {
+      openapi: "3.0.0",
+      servers: [{ url: "https://root.example.com" }],
+      paths: { "/data": { servers: [{ url: "https://path-override.example.com" }], get: { summary: "d" } } },
+    };
+
+    const capturedConfigs: unknown[] = [];
+    const fakeHttpClient: HttpClient = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      request: async (config: any) => {
+        capturedConfigs.push(config);
+        return { status: 200, statusText: "OK", headers: {}, config, data: {} };
+      },
+    };
+    const { profileStore, openapiLoader } = createCliDeps(cwd, homeDir, {
+      [`${localDir}/profiles.ini`]: ["[ps]", "api_base_url = https://profile.example.com", `openapi_spec_cache = ${cachePath}`, ""].join("\n"),
+      [cachePath]: JSON.stringify(spec),
+      [`${localDir}/current`]: "ps",
+    });
+
+    await run(["data"], { cwd, profileStore, openapiLoader, httpClient: fakeHttpClient, stdout: () => {} });
+
+    const config = capturedConfigs[0] as { url: string };
+    expect(config.url).toBe("https://path-override.example.com/data");
+  });
 });


### PR DESCRIPTION
## Problem

When using a public OpenAPI/Swagger spec with a self-hosted instance, `--api-base-url` from the profile is silently ignored.

**Root cause:** In `buildRequestUrl()` (`cli.ts:250`), `command.serverUrl` always takes priority over `profile.apiBaseUrl` via the `??` operator. For Swagger 2.0 specs, `serverUrl` is always populated from the `host` field (e.g. `host: gitlab.com`). For OpenAPI 3.0 — from root `servers`. So the user's explicit `--api-base-url` never wins.

**Real-world scenario:** Self-hosted GitLab (v18.8.2) does not serve its own OpenAPI spec. The only way to get it is from `gitlab.com`, where `host: gitlab.com` is hardcoded. Same applies to any self-hosted service where the spec is downloaded from public docs.

## Fix

Add `serverUrlOverridesProfile` boolean to `CliCommand`. When the server URL comes from **operation-level** or **path-level** `servers` (OpenAPI 3.0 per-endpoint routing), the flag is `true` and the spec URL wins. When it comes from **root-level** `host`/`servers`, the flag is `false` and `profile.apiBaseUrl` takes priority.

**Priority order:**
1. Operation/path-level `servers` — highest (intentional per-endpoint routing)
2. `profile.apiBaseUrl` — user's explicit choice
3. Root-level `host`/`servers` — fallback

**Backward compatible:** When `apiBaseUrl` and spec host point to the same server (the typical case), behavior is unchanged.

## Changes

- `src/openapi-to-commands.ts` — `resolveOperationServerUrl()` returns `{ url, overridesProfile }` instead of plain string
- `src/cli.ts` — `buildRequestUrl()` checks `serverUrlOverridesProfile` before choosing base URL
- `tests/cli.test.ts` — 3 new tests: Swagger 2.0 host override, OpenAPI 3.0 root servers override, path-level servers still win

## Test plan

- [x] All existing tests pass (106 tests, 80 passed, 26 skipped, 0 failed)
- [x] New test: profile `apiBaseUrl` overrides Swagger 2.0 `host`
- [x] New test: profile `apiBaseUrl` overrides OpenAPI 3.0 root `servers`
- [x] New test: path-level `servers` still override profile `apiBaseUrl`
- [x] Existing test: operation-level `servers` still override profile `apiBaseUrl`